### PR TITLE
Add non-protected `registry_key_exist?`

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -15,9 +15,9 @@ module Registry
   #
   def registry_loadkey(key,file)
     if session_has_registry_ext
-      retval=meterpreter_registry_loadkey(key,file)
+      retval = meterpreter_registry_loadkey(key,file)
     else
-      retval=shell_registry_loadkey(key,file)
+      retval = shell_registry_loadkey(key,file)
     end
     return retval
   end
@@ -27,11 +27,28 @@ module Registry
   #
   def registry_unloadkey(key)
     if session_has_registry_ext
-      retval=meterpreter_registry_unloadkey(key)
+      retval = meterpreter_registry_unloadkey(key)
     else
-      retval=shell_registry_unloadkey(key)
+      retval = shell_registry_unloadkey(key)
     end
     return retval
+  end
+
+  # Whether a remote key exists
+  #
+  # @example
+  #   registry_key_exist?("HKCU\\Environment") # => true
+  #   registry_key_exist?("HKEY_CURRENT_USER\\Environment") # => true
+  #   registry_key_exist?("HKLM\\Non\\Existent\\Key") # => false
+  #
+  # @param key [String] A registry key name including the root
+  def registry_key_exist?(key)
+    if session_has_registry_ext
+      return meterpreter_registry_key_exist?(key)
+    else
+      # XXX implement for shell
+      raise RuntimeError, "Unsupported session"
+    end
   end
 
   #
@@ -445,7 +462,7 @@ protected
   #
   # Check if a registry key exists
   #
-  def meterpreter_registry_checkkeyexists(key)
+  def meterpreter_registry_key_exist?(key)
     begin
       root_key, base_key = session.sys.registry.splitkey(key)
       return session.sys.registry.check_key_exists(root_key, base_key)

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -1,9 +1,7 @@
 
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
@@ -32,7 +30,7 @@ class Metasploit3 < Msf::Post
   end
 
   def test_0_registry_read
-    pending "should evaluate key existence" do
+    it "should evaluate key existence" do
       # these methods are not implemented
       k_exists = registry_key_exist?(%q#HKCU\Environment#)
       k_dne    = registry_key_exist?(%q#HKLM\\Non\Existent\Key#)


### PR DESCRIPTION
Also enables previously-pending test in post/test/registry

See rapid7/metasploit-framework#2686
