### PR TITLE
Update specs & bins for dynamic-size stageless meterpreter payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.29.0)
-      meterpreter_bins (= 0.0.14)
+      meterpreter_bins (= 0.0.15)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -132,7 +132,7 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.14)
+    meterpreter_bins (0.0.15)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.14'
+  spec.add_runtime_dependency 'meterpreter_bins', '0.0.15'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = :dynamic
+
   include Msf::Payload::Windows::StagelessMeterpreter
   include Msf::Sessions::MeterpreterOptions
 

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = :dynamic
+
   include Msf::Payload::Windows::StagelessMeterpreter
   include Msf::Sessions::MeterpreterOptions
 

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = :dynamic
+
   include Msf::Payload::Windows::StagelessMeterpreter
   include Msf::Sessions::MeterpreterOptions
 

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = :dynamic
+
   include Msf::Payload::Windows::StagelessMeterpreter
   include Msf::Sessions::MeterpreterOptions
 

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2432,6 +2432,46 @@ describe 'modules/payloads', :content do
                           reference_name: 'windows/messagebox'
   end
 
+  context 'windows/meterpreter_bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/meterpreter_bind_tcp'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/meterpreter_bind_tcp'
+  end
+
+  context 'windows/meterpreter_reverse_https' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/meterpreter_reverse_https'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/meterpreter_reverse_https'
+  end
+
+  context 'windows/meterpreter_reverse_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/meterpreter_reverse_ipv6_tcp'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/meterpreter_reverse_ipv6_tcp'
+  end
+
+  context 'windows/meterpreter_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/meterpreter_reverse_tcp'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/meterpreter_reverse_tcp'
+  end
+
   context 'windows/meterpreter/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This should do the trick for getting specs passing again with the stageless meterpreter branch on MSF. I published an updated bins gem to match.