### PR TITLE
Initial implementation of ext in Post namespace

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -13,6 +13,11 @@ module Exploit::Powershell
         OptBool.new('Powershell::strip_whitespace', [true, 'Strip whitespace', false]),
         OptBool.new('Powershell::sub_vars', [true, 'Substitute variable names', false]),
         OptBool.new('Powershell::sub_funcs', [true, 'Substitute function names', false]),
+        OptBool.new('Powershell::exec_in_place', [true, 'Produce PSH without executable wrapper', false]),
+        OptBool.new('Powershell::encode_final_payload', [true, 'Encode final payload for -EncodedCommand', false]),
+        OptBool.new('Powershell::encode_inner_payload', [true, 'Encode inner payload for -EncodedCommand', false]),
+        OptBool.new('Powershell::use_single_quotes', [true, 'Wraps the -Command argument in single quotes', false]),
+        OptBool.new('Powershell::no_equals', [true, 'Pad base64 until no "=" remains', false]),
         OptEnum.new('Powershell::method', [true, 'Payload delivery method', 'reflection', %w(net reflection old msil)]),
       ], self.class)
   end
@@ -49,6 +54,7 @@ module Exploit::Powershell
 
     script
   end
+
   #
   # Return an encoded powershell script
   # Will invoke PSH modifiers as enabled
@@ -67,6 +73,21 @@ module Exploit::Powershell
   end
 
   #
+  # Return an decoded powershell script
+  #
+  # @param script_in [String] Encoded contents
+  #
+  # @return [String] Decoded script
+  def decode_script(script_in)
+    if script_in.to_s.match( /[A-Za-z0-9+\/]+={0,3}/)[0] == script_in.to_s and 
+    script_in.to_s.length % 4 == 0
+      return Rex::Powershell::Command.decode_script(script_in)
+    else
+      return script_in
+    end
+  end
+
+  #
   # Return a gzip compressed powershell script
   # Will invoke PSH modifiers as enabled
   #
@@ -82,6 +103,17 @@ module Exploit::Powershell
     end
 
     Rex::Powershell::Command.compress_script(script_in, eof, opts)
+  end
+
+  #
+  # Return a decompressed powershell sript
+  #
+  # @param script_in [String] Compressed contents with decompression stub
+  #
+  # @return [String] Decompressed script
+  def decompress_script(script_in)
+    return script_in if script_in.match(/FromBase64String/).nil?
+    Rex::Powershell::Command.decompress_script(script_in)
   end
 
   #
@@ -187,13 +219,16 @@ module Exploit::Powershell
   #
   # @return [String] Powershell command line with payload
   def cmd_psh_payload(pay, payload_arch, opts = {})
-    opts[:persist] ||= datastore['Powershell::persist']
-    opts[:prepend_sleep] ||= datastore['Powershell::prepend_sleep']
-    opts[:method] ||= datastore['Powershell::method']
+    options.validate(datastore)
+
+    [ :persist, :prepend_sleep, :exec_in_place, :encode_final_payload,
+      :encode_inner_payload, :use_single_quotes, :no_equals, :method ].map { |opt|
+      opts[opt] ||= datastore["Powershell::#{opt}"]
+    }
 
     unless opts.key? :shorten
       opts[:shorten] = (datastore['Powershell::method'] != 'old')
-    end
+    end 
     template_path = File.join(Msf::Config.data_directory,
                               "templates",
                               "scripts")
@@ -205,7 +240,7 @@ module Exploit::Powershell
     vprint_status("Powershell command length: #{command.length}")
 
     command
-  end
+  end 
 
 
   #
@@ -213,6 +248,7 @@ module Exploit::Powershell
   #
   module PshMethods
     include Rex::Powershell::PshMethods
-  end
+  end 
 end
 end
+


### PR DESCRIPTION
Update Msf::Post::Windows::Powershell to make use of the new
extension with a load method analogous to that found in extapi.
Update the powershell execution methods in the namespace to utilize
the loaded extension if available.
Expose Rex::Powershell::Output decode_code and decompress_code
methods to Msf::Exploit and the inheriting Post..Powershell space,
utilize these methods to extract raw PSH from the potentially
encoded contents of script being passed into execute_script and
psh_exec.

---

Testing: basic functional tests in lab environment - successfully ran
PSH code via the ext from post module call to psh_exec('ls C:\ ')
