### PR TITLE
Add UUIDs to mettle stages

### DIFF
--- a/modules/payloads/stages/linux/armle/mettle.rb
+++ b/modules/payloads/stages/linux/armle/mettle.rb
@@ -79,7 +79,9 @@ module MetasploitModule
     conn.put(midstager) == midstager.length
   end
 
-  def generate_stage(_opts = {})
-    MetasploitPayloads::Mettle.read('armv5l-linux-musleabi', 'mettle.bin')
+  def generate_stage(opts = {})
+    opts[:uuid] ||= generate_payload_uuid
+    MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', opts.slice(:uuid, :url, :debug, :log_file)).
+      to_bininary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsbe/mettle.rb
+++ b/modules/payloads/stages/linux/mipsbe/mettle.rb
@@ -90,7 +90,9 @@ module MetasploitModule
     conn.put(midstager) == midstager.length
   end
 
-  def generate_stage(_opts = {})
-    MetasploitPayloads::Mettle.read('mips-linux-muslsf', 'mettle.bin')
+  def generate_stage(opts = {})
+    opts[:uuid] ||= generate_payload_uuid
+    MetasploitPayloads::Mettle.new('mips-linux-muslsf', opts.slice(:uuid, :url, :debug, :log_file)).
+      to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsle/mettle.rb
+++ b/modules/payloads/stages/linux/mipsle/mettle.rb
@@ -90,7 +90,9 @@ module MetasploitModule
     conn.put(midstager) == midstager.length
   end
 
-  def generate_stage(_opts = {})
-    MetasploitPayloads::Mettle.read('mipsel-linux-muslsf', 'mettle.bin')
+  def generate_stage(opts = {})
+    opts[:uuid] ||= generate_payload_uuid
+    MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', opts.slice(:uuid, :url, :debug, :log_file)).
+      to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x64/mettle.rb
+++ b/modules/payloads/stages/linux/x64/mettle.rb
@@ -87,7 +87,9 @@ module MetasploitModule
     conn.put(midstager) == midstager.length
   end
 
-  def generate_stage(_opts = {})
-    MetasploitPayloads::Mettle.read('x86_64-linux-musl', 'mettle.bin')
+  def generate_stage(opts = {})
+    opts[:uuid] ||= generate_payload_uuid
+    MetasploitPayloads::Mettle.new('x86_64-linux-musl', opts.slice(:uuid, :url, :debug, :log_file)).
+      to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x86/mettle.rb
+++ b/modules/payloads/stages/linux/x86/mettle.rb
@@ -90,7 +90,9 @@ module MetasploitModule
     conn.put(midstager) == midstager.length
   end
 
-  def generate_stage(_opts = {})
-    MetasploitPayloads::Mettle.read('i486-linux-musl', 'mettle.bin')
+  def generate_stage(opts = {})
+    opts[:uuid] ||= generate_payload_uuid
+    MetasploitPayloads::Mettle.new('i486-linux-musl', opts.slice(:uuid, :url, :debug, :log_file)).
+      to_binary :process_image
   end
 end


### PR DESCRIPTION
!!! Requires rapid7/mettle#36 to work

Verification
========

- [ ] Point MSF to the new mettle gem
- [ ] Mettle payloads should continue to generate and should have consistent UUIDs