### PR TITLE
fix android/meterpreter/reverse_http

### DIFF
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -51,7 +51,7 @@ module Msf::Payload::Android
       arch:       opts[:uuid].arch,
       expiration: ds['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
-      transports: [transport_config(opts)]
+      transports: opts[:transport_config] || [transport_config(opts)]
     }
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)

--- a/lib/msf/core/payload/android/meterpreter_loader.rb
+++ b/lib/msf/core/payload/android/meterpreter_loader.rb
@@ -55,25 +55,6 @@ module Payload::Android::MeterpreterLoader
     (blocks + [blocks.length]).pack('A*' * blocks.length + 'N')
   end
 
-  def generate_config(opts={})
-    opts[:uuid] ||= generate_payload_uuid
-    ds = opts[:datastore] || datastore
-
-    # create the configuration block, which for staged connections is really simple.
-    config_opts = {
-      ascii_str:  true,
-      arch:       opts[:uuid].arch,
-      expiration: ds['SessionExpirationTimeout'].to_i,
-      uuid:       opts[:uuid],
-      transports: opts[:transport_config] || [transport_config(opts)]
-    }
-
-    # create the configuration instance based off the parameters
-    config = Rex::Payloads::Meterpreter::Config.new(config_opts)
-
-    # return the XML version of it
-    config.to_b
-  end
 end
 end
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -14,7 +14,7 @@ module MetasploitModule
 
   include Msf::Payload::Stager
   include Msf::Payload::Android
-  include Msf::Payload::Android::ReverseHttp
+  include Msf::Payload::Android::ReverseHttps
 
   def initialize(info = {})
     super(merge_info(info,


### PR DESCRIPTION
This fixes the android/meterpreter/reverse_http payload.
I'm still working on a fix for android/meterpreter/reverse_https
Currently it's giving me:
`[-] https://<snip>:4444 handling request from <snip>; (UUID: yhq0dypq) Staging failed. This can occur when stageless listeners are used with staged payloads.`
android/meterpreter_reverse_http is working as is.
Great work!