### PR TITLE
remove AutoLoadAndroid option

### DIFF
--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -67,9 +67,7 @@ module MeterpreterOptions
       end
 
       if session.platform == 'android'
-        if datastore['AutoLoadAndroid']
-          session.load_android
-        end
+        session.load_android
       end
 
       [ 'InitialAutoRunScript', 'AutoRunScript' ].each do |key|

--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -323,7 +323,7 @@ module Msf
         multi_handler.datastore['PAYLOAD']              = payload_name
         multi_handler.datastore['LPORT']                = wanted[:payload_lport]
 
-        %w(DebugOptions AutoLoadAndroid PrependMigrate PrependMigrateProc
+        %w(DebugOptions PrependMigrate PrependMigrateProc
            InitialAutoRunScript AutoRunScript CAMPAIGN_ID HandlerSSLCert
            StagerVerifySSLCert PayloadUUIDTracking PayloadUUIDName
            IgnoreUnknownPayloads SessionRetryTotal SessionRetryWait

--- a/lib/msf/core/payload/android/meterpreter_loader.rb
+++ b/lib/msf/core/payload/android/meterpreter_loader.rb
@@ -28,10 +28,6 @@ module Payload::Android::MeterpreterLoader
       'PayloadCompat' => {'Convention' => 'http https'},
       'Stage'         => {'Payload' => ''}
     ))
-
-    register_options([
-      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
-    ])
   end
 
   def stage_payload(opts={})

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -35,9 +35,6 @@ module MetasploitModule
       'Session'     => Msf::Sessions::Meterpreter_Java_Android,
       'Payload'     => '',
       ))
-    register_options([
-      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
-    ], self.class)
   end
 
   #

--- a/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
@@ -30,9 +30,6 @@ module MetasploitModule
       'Session'     => Msf::Sessions::Meterpreter_Java_Android,
       'Payload'     => '',
     ))
-    register_options([
-      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
-    ], self.class)
   end
 
   #


### PR DESCRIPTION
the AutoLoadAndroid option is not set if you do:
```
use exploit/multi/handler
set payload multi/meterpreter/reverse_http
```
It seems easiest to remove it entirely as it's not actually loading anything, just making the commands available.