### PR TITLE
unify http and retry options between payloads

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -52,16 +52,38 @@ module ReverseHttp
 
     register_advanced_options(
       [
-
-        OptString.new('MeterpreterUserAgent', [false, 'The user-agent that the payload should use for communication', Rex::UserAgent.shortest]),
-        OptString.new('MeterpreterServerName', [false, 'The server header that the handler will send in response to requests', 'Apache']),
-        OptAddress.new('ReverseListenerBindAddress', [false, 'The specific IP address to bind to on the local system']),
-        OptBool.new('OverrideRequestHost', [false, 'Forces a specific host and port instead of using what the client requests, defaults to LHOST:LPORT', false]),
-        OptString.new('OverrideLHOST', [false, 'When OverrideRequestHost is set, use this value as the host name for secondary requests']),
-        OptPort.new('OverrideLPORT', [false, 'When OverrideRequestHost is set, use this value as the port number for secondary requests']),
-        OptString.new('OverrideScheme', [false, 'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https']),
-        OptString.new('HttpUnknownRequestResponse', [false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>']),
-        OptBool.new('IgnoreUnknownPayloads', [false, 'Whether to drop connections from payloads using unknown UUIDs', false])
+        OptAddress.new('ReverseListenerBindAddress',
+          'The specific IP address to bind to on the local system'
+        ),
+        OptBool.new('OverrideRequestHost',
+          'Forces a specific host and port instead of using what the client requests, defaults to LHOST:LPORT',
+        ),
+        OptString.new('OverrideLHOST',
+          'When OverrideRequestHost is set, use this value as the host name for secondary requests'
+        ),
+        OptPort.new('OverrideLPORT',
+          'When OverrideRequestHost is set, use this value as the port number for secondary requests'
+        ),
+        OptString.new('OverrideScheme',
+          'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https'
+        ),
+        OptString.new('HttpUserAgent',
+          'The user-agent that the payload should use for communication',
+          default: Rex::UserAgent.shortest,
+          aliases: ['MeterpreterUserAgent']
+        ),
+        OptString.new('HttpServerName',
+          'The server header that the handler will send in response to requests',
+          default: 'Apache',
+          aliases: ['MeterpreterServerName']
+        ),
+        OptString.new('HttpUnknownRequestResponse',
+          'The returned HTML response body when the handler receives a request that is not from a payload',
+          default: '<html><body><h1>It works!</h1></body></html>'
+        ),
+        OptBool.new('IgnoreUnknownPayloads',
+          'Whether to drop connections from payloads using unknown UUIDs'
+        )
       ], Msf::Handler::ReverseHttp)
   end
 
@@ -204,7 +226,7 @@ module ReverseHttp
 
     raise ex if (ex)
 
-    self.service.server_name = datastore['MeterpreterServerName']
+    self.service.server_name = datastore['HttpServerName']
 
     # Add the new resource
     service.add_resource((luri + "/").gsub("//", "/"),
@@ -245,14 +267,14 @@ protected
     info = {}
     return @proxy_settings if @proxy_settings
 
-    if datastore['PayloadProxyHost'].to_s == ''
+    if datastore['HttpProxyHost'].to_s == ''
       @proxy_settings = info
       return @proxy_settings
     end
 
-    info[:host] = datastore['PayloadProxyHost'].to_s
-    info[:port] = (datastore['PayloadProxyPort'] || 8080).to_i
-    info[:type] = datastore['PayloadProxyType'].to_s
+    info[:host] = datastore['HttpProxyHost'].to_s
+    info[:port] = (datastore['HttpProxyPort'] || 8080).to_i
+    info[:type] = datastore['HttpProxyType'].to_s
 
     uri_host = info[:host]
 
@@ -266,11 +288,11 @@ protected
       info[:info] = "socks=#{info[:info]}"
     else
       info[:info] = "http://#{info[:info]}"
-      if datastore['PayloadProxyUser'].to_s != ''
-        info[:username] = datastore['PayloadProxyUser'].to_s
+      if datastore['HttpProxyUser'].to_s != ''
+        info[:username] = datastore['HttpProxyUser'].to_s
       end
-      if datastore['PayloadProxyPass'].to_s != ''
-        info[:password] = datastore['PayloadProxyPass'].to_s
+      if datastore['HttpProxyPass'].to_s != ''
+        info[:password] = datastore['HttpProxyPass'].to_s
       end
     end
 

--- a/lib/msf/core/handler/reverse_https_proxy.rb
+++ b/lib/msf/core/handler/reverse_https_proxy.rb
@@ -38,13 +38,13 @@ module ReverseHttpsProxy
 
     register_options(
       [
-        OptAddressLocal.new('LHOST', [ true, "The local listener hostname" ,"127.0.0.1"]),
-        OptPort.new('LPORT', [ true, "The local listener port", 8443 ]),
-        OptString.new('PayloadProxyHost', [true, "The proxy server's IP address", "127.0.0.1"]),
-        OptPort.new('PayloadProxyPort', [true, "The proxy port to connect to", 8080 ]),
-        OptEnum.new('PayloadProxyType', [true, 'The proxy type, HTTP or SOCKS', 'HTTP', ['HTTP', 'SOCKS']]),
-        OptString.new('PayloadProxyUser', [ false, "An optional username for HTTP proxy authentication"]),
-        OptString.new('PayloadProxyPass', [ false, "An optional password for HTTP proxy authentication"])
+        OptAddressLocal.new('LHOST', "The local listener hostname", default: "127.0.0.1"),
+        OptPort.new('LPORT', "The local listener port", default: 8443),
+        OptString.new('HttpProxyHost', "The proxy server's IP address", required: true, default: "127.0.0.1", aliases: ['PayloadProxyHost']),
+        OptPort.new('HttpProxyPort', "The proxy port to connect to", required: true, default: 8080, aliases: ['PayloadProxyPort']),
+        OptEnum.new('HttpProxyType', 'The proxy type, HTTP or SOCKS', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType']),
+        OptString.new('HttpProxyUser', "An optional username for HTTP proxy authentication", aliases: ['PayloadProxyUser']),
+        OptString.new('HttpProxyPass', "An optional password for HTTP proxy authentication", aliases: ['PayloadProxyPass'])
       ], Msf::Handler::ReverseHttpsProxy)
 
     register_advanced_options(

--- a/lib/msf/core/handler/reverse_https_proxy.rb
+++ b/lib/msf/core/handler/reverse_https_proxy.rb
@@ -39,13 +39,10 @@ module ReverseHttpsProxy
     register_options(
       [
         OptAddressLocal.new('LHOST', "The local listener hostname", default: "127.0.0.1"),
-        OptPort.new('LPORT', "The local listener port", default: 8443),
-        OptString.new('HttpProxyHost', "The proxy server's IP address", required: true, default: "127.0.0.1", aliases: ['PayloadProxyHost']),
-        OptPort.new('HttpProxyPort', "The proxy port to connect to", required: true, default: 8080, aliases: ['PayloadProxyPort']),
-        OptEnum.new('HttpProxyType', 'The proxy type, HTTP or SOCKS', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType']),
-        OptString.new('HttpProxyUser', "An optional username for HTTP proxy authentication", aliases: ['PayloadProxyUser']),
-        OptString.new('HttpProxyPass', "An optional password for HTTP proxy authentication", aliases: ['PayloadProxyPass'])
-      ], Msf::Handler::ReverseHttpsProxy)
+        OptPort.new('LPORT', "The local listener port", default: 8443)
+      ] +
+      Msf::Opt::http_proxy_options,
+      Msf::Handler::ReverseHttpsProxy)
 
     register_advanced_options(
       [

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -45,15 +45,6 @@ module ReverseTcp
     # XXX: Not supported by all modules
     register_advanced_options(
       [
-        OptInt.new(
-          'StagerRetryCount',
-          [ true, 'The number of connection attempts to try before exiting the process', 10 ],
-          aliases: ['ReverseConnectRetries']
-        ),
-        OptFloat.new(
-          'StagerRetryWait',
-          [ false, 'Number of seconds to wait for the stager between reconnect attempts', 5.0 ]
-        ),
         OptAddress.new(
           'ReverseListenerBindAddress',
           [ false, 'The specific IP address to bind to on the local system' ]
@@ -62,7 +53,8 @@ module ReverseTcp
           'ReverseListenerThreaded',
           [ true, 'Handle every connection in a new thread (experimental)', false ]
         )
-      ],
+      ] +
+      Msf::Opt::stager_retry_options,
       Msf::Handler::ReverseTcp
     )
 

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
 module Msf
-
   #
   # Builtin framework options with shortcut methods
   #
@@ -59,17 +58,6 @@ module Msf
       )
     end
 
-    # These are unused but remain for historical reasons
-    class << self
-      alias builtin_chost CHOST
-      alias builtin_cport CPORT
-      alias builtin_lhost LHOST
-      alias builtin_lport LPORT
-      alias builtin_proxies Proxies
-      alias builtin_rhost RHOST
-      alias builtin_rport RPORT
-    end
-
     CHOST = CHOST()
     CPORT = CPORT()
     LHOST = LHOST()
@@ -79,5 +67,4 @@ module Msf
     RPORT = RPORT()
     SSLVersion = SSLVersion()
   end
-
 end

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -53,9 +53,10 @@ module Msf
 
     # @return [OptEnum]
     def self.SSLVersion
-      Msf::OptEnum.new('SSLVersion', [ false,
-        'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)', 'Auto',
-        ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']])
+      Msf::OptEnum.new('SSLVersion',
+        'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
+        enums: ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']
+      )
     end
 
     # These are unused but remain for historical reasons

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -52,10 +52,75 @@ module Msf
 
     # @return [OptEnum]
     def self.SSLVersion
-      Msf::OptEnum.new('SSLVersion',
+      Msf::OptEnum.new(
+        'SSLVersion',
         'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
         enums: ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']
       )
+    end
+
+    def self.stager_retry_options
+      [
+        OptInt.new(
+          'StagerRetryCount',
+          'The number of times the stager should retry if the first connect fails',
+          default: 10,
+          aliases: ['ReverseConnectRetries']
+        ),
+        OptInt.new(
+          'StagerRetryWait',
+          'Number of seconds to wait for the stager between reconnect attempts',
+          default: 5
+        )
+      ]
+    end
+
+    def self.http_proxy_options
+      [
+        OptString.new(
+          'HttpProxyHost',
+          'An optional proxy server IP address or hostname',
+          aliases: ['PayloadProxyHost']
+        ),
+        OptPort.new(
+          'HttpProxyPort',
+          'An optional proxy server port',
+          aliases: ['PayloadProxyPort']
+        ),
+        OptString.new(
+          'HttpProxyUser',
+          'An optional proxy server username',
+          aliases: ['PayloadProxyUser']
+        ),
+        OptString.new(
+          'HttpProxyPass',
+          'An optional proxy server password',
+          aliases: ['PayloadProxyPass']
+        ),
+        OptEnum.new(
+          'HttpProxyType',
+          'The type of HTTP proxy',
+          enums: ['HTTP', 'SOCKS'],
+          aliases: ['PayloadProxyType']
+        )
+      ]
+    end
+
+    def self.http_header_options
+      [
+        OptString.new(
+          'HttpHeaderHost',
+          'An optional value to use for the Host HTTP header'
+        ),
+        OptString.new(
+          'HttpHeaderCookie',
+          'An optional value to use for the Cookie HTTP header'
+        ),
+        OptString.new(
+          'HttpHeaderReferer',
+          'An optional value to use for the Referer HTTP header'
+        )
+      ]
     end
 
     CHOST = CHOST()

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -52,8 +52,7 @@ module Msf
 
     # @return [OptEnum]
     def self.SSLVersion
-      Msf::OptEnum.new(
-        'SSLVersion',
+      Msf::OptEnum.new('SSLVersion',
         'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
         enums: ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']
       )
@@ -61,14 +60,12 @@ module Msf
 
     def self.stager_retry_options
       [
-        OptInt.new(
-          'StagerRetryCount',
+        OptInt.new('StagerRetryCount',
           'The number of times the stager should retry if the first connect fails',
           default: 10,
           aliases: ['ReverseConnectRetries']
         ),
-        OptInt.new(
-          'StagerRetryWait',
+        OptInt.new('StagerRetryWait',
           'Number of seconds to wait for the stager between reconnect attempts',
           default: 5
         )
@@ -77,29 +74,19 @@ module Msf
 
     def self.http_proxy_options
       [
-        OptString.new(
-          'HttpProxyHost',
-          'An optional proxy server IP address or hostname',
+        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname',
           aliases: ['PayloadProxyHost']
         ),
-        OptPort.new(
-          'HttpProxyPort',
-          'An optional proxy server port',
+        OptPort.new('HttpProxyPort', 'An optional proxy server port',
           aliases: ['PayloadProxyPort']
         ),
-        OptString.new(
-          'HttpProxyUser',
-          'An optional proxy server username',
+        OptString.new('HttpProxyUser', 'An optional proxy server username',
           aliases: ['PayloadProxyUser']
         ),
-        OptString.new(
-          'HttpProxyPass',
-          'An optional proxy server password',
+        OptString.new('HttpProxyPass', 'An optional proxy server password',
           aliases: ['PayloadProxyPass']
         ),
-        OptEnum.new(
-          'HttpProxyType',
-          'The type of HTTP proxy',
+        OptEnum.new('HttpProxyType', 'The type of HTTP proxy',
           enums: ['HTTP', 'SOCKS'],
           aliases: ['PayloadProxyType']
         )
@@ -108,18 +95,9 @@ module Msf
 
     def self.http_header_options
       [
-        OptString.new(
-          'HttpHeaderHost',
-          'An optional value to use for the Host HTTP header'
-        ),
-        OptString.new(
-          'HttpHeaderCookie',
-          'An optional value to use for the Cookie HTTP header'
-        ),
-        OptString.new(
-          'HttpHeaderReferer',
-          'An optional value to use for the Referer HTTP header'
-        )
+        OptString.new('HttpHostHeader', 'An optional value to use for the Host HTTP header'),
+        OptString.new('HttpCookie', 'An optional value to use for the Cookie HTTP header'),
+        OptString.new('HttpReferer', 'An optional value to use for the Referer HTTP header')
       ]
     end
 

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -36,14 +36,14 @@ module Msf
         self.required = required
         self.desc     = attrs.is_a?(String) ? attrs : desc
         self.enums    = [ *(enums) ].map { |x| x.to_s }
-        if default.nil? && enums.length > 0
-          self.default  = enums[0]
-        else
-          self.default = default
-        end
+        self.default  = default
         regex_temp    = regex
       else
-        self.required = attrs[0] || required
+        if attrs[0].nil?
+          self.required = required
+        else
+          self.required = attrs[0]
+        end
         self.desc     = attrs[1] || desc
         self.default  = attrs[2] || default
         self.enums    = attrs[3] || enums

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -22,15 +22,31 @@ module Msf
     # attrs[3] = possible enum values
     # attrs[4] = Regex to validate the option
     #
-    def initialize(in_name, attrs = [], aliases: [])
+    # Attrs can also be specified explicitly via named parameters, or attrs can
+    # also be a string as standin for the required description field.
+    #
+    def initialize(in_name, attrs = [],
+                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [])
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
-      self.required = attrs[0] || false
-      self.desc     = attrs[1]
-      self.default  = attrs[2]
-      self.enums    = [ *(attrs[3]) ].map { |x| x.to_s }
-      regex_temp    = attrs[4] || nil
+      self.aliases  = aliases
+
+      if attrs.is_a?(String) || attrs.length == 0
+        self.required = required
+        self.desc     = attrs.is_a?(String) ? attrs : desc
+        self.enums    = [ *(enums) ].map { |x| x.to_s }
+        self.default  = default || enums[0]
+        regex_temp    = regex
+      else
+        self.required = attrs[0] || required
+        self.desc     = attrs[1] || desc
+        self.default  = attrs[2] || default
+        self.enums    = attrs[3] || enums
+        self.enums    = [ *(self.enums) ].map { |x| x.to_s }
+        regex_temp    = attrs[4] || regex
+      end
+
       if regex_temp
         # convert to string
         regex_temp = regex_temp.to_s if regex_temp.is_a? Regexp
@@ -45,35 +61,34 @@ module Msf
           raise("Invalid Regex #{regex_temp}: #{e}")
         end
       end
-      self.aliases = aliases
     end
 
     #
     # Returns true if this is a required option.
     #
     def required?
-      return required
+      required
     end
 
     #
     # Returns true if this is an advanced option.
     #
     def advanced?
-      return advanced
+      advanced
     end
 
     #
     # Returns true if this is an evasion option.
     #
     def evasion?
-      return evasion
+      evasion
     end
 
     #
     # Returns true if the supplied type is equivalent to this option's type.
     #
     def type?(in_type)
-      return (type == in_type)
+      type == in_type
     end
 
     #
@@ -94,7 +109,7 @@ module Msf
       if regex
         return !!value.match(regex)
       end
-      return true
+      true
     end
 
     #
@@ -102,7 +117,7 @@ module Msf
     # a valid value
     #
     def empty_required_value?(value)
-      return (required? and value.nil?)
+      required? && value.nil?
     end
 
     #
@@ -169,6 +184,4 @@ module Msf
 
     attr_writer   :required, :desc, :default # :nodoc:
   end
-
 end
-

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -36,7 +36,11 @@ module Msf
         self.required = required
         self.desc     = attrs.is_a?(String) ? attrs : desc
         self.enums    = [ *(enums) ].map { |x| x.to_s }
-        self.default  = default || enums[0]
+        if default.nil? && enums.length > 0
+          self.default  = enums[0]
+        else
+          self.default = default
+        end
         regex_temp    = regex
       else
         self.required = attrs[0] || required

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -36,8 +36,12 @@ module Msf
         self.required = required
         self.desc     = attrs.is_a?(String) ? attrs : desc
         self.enums    = [ *(enums) ].map { |x| x.to_s }
-        self.default  = default
-        regex_temp    = regex
+        if default.nil? && enums.length > 0
+          self.default = enums[0]
+        else
+          self.default = default
+        end
+        regex_temp = regex
       else
         if attrs[0].nil?
           self.required = required

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -1,48 +1,31 @@
 # -*- coding: binary -*-
 
 module Msf
+  # Boolean option type
+  class OptBool < OptBase
+    TRUE_REGEX = /^(y|yes|t|1|true)$/i
+    ANY_REGEX = /^(y|yes|n|no|t|f|0|1|true|false)$/i
 
-###
-#
-# Boolean option.
-#
-###
-class OptBool < OptBase
-
-  TrueRegex = /^(y|yes|t|1|true)$/i
-
-  def type
-    return 'bool'
-  end
-
-  def valid?(value, check_empty: true)
-    return false if empty_required_value?(value)
-
-    if ((value != nil and
-        (value.to_s.empty? == false) and
-        (value.to_s.match(/^(y|yes|n|no|t|f|0|1|true|false)$/i) == nil)))
-      return false
+    # This overrides default from 'nil' to 'false'
+    def initialize(in_name, attrs = [],
+                   required: true, desc: nil, default: false, aliases: [])
+      super
     end
 
-    true
-  end
+    def type
+      return 'bool'
+    end
 
-  def normalize(value)
-    if(value.nil? or value.to_s.match(TrueRegex).nil?)
-      false
-    else
-      true
+    def valid?(value, check_empty: true)
+      return false if check_empty && empty_required_value?(value)
+      !(value.nil? ||
+        value.to_s.empty? ||
+        value.to_s.match(ANY_REGEX).nil?)
+    end
+
+    def normalize(value)
+      !(value.nil? ||
+        value.to_s.match(TRUE_REGEX).nil?)
     end
   end
-
-  def is_true?(value)
-    return normalize(value)
-  end
-
-  def is_false?(value)
-    return !is_true?(value)
-  end
-
-end
-
 end

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -18,6 +18,8 @@ module Msf
 
     def valid?(value, check_empty: true)
       return false if check_empty && empty_required_value?(value)
+      return true if value.nil? && !required?
+
       !(value.nil? ||
         value.to_s.empty? ||
         value.to_s.match(ANY_REGEX).nil?)

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -1,48 +1,45 @@
 # -*- coding: binary -*-
 
 module Msf
-
-###
-#
-# Enum option.
-#
-###
-class OptEnum < OptBase
-
-  def type
-    return 'enum'
-  end
-
-  def valid?(value=self.value, check_empty: true)
-    return false if check_empty && empty_required_value?(value)
-    return true if value.nil? and !required?
-
-    (value and self.enums.include?(value.to_s))
-  end
-
-  def normalize(value=self.value)
-    return nil if not self.valid?(value)
-    return value.to_s
-  end
-
-  def desc=(value)
-    self.desc_string = value
-
-    self.desc
-  end
-
-  def desc
-    if self.enums
-      str = self.enums.join(', ')
+  ###
+  #
+  # Enum option.
+  #
+  ###
+  class OptEnum < OptBase
+    def type
+      return 'enum'
     end
-    "#{self.desc_string || ''} (Accepted: #{str})"
+
+    # This overrides required default from 'false' to 'true'
+    def initialize(in_name, attrs = [],
+                   required: true, desc: nil, default: nil, enums: [], aliases: [])
+      super
+    end
+
+    def valid?(value = self.value, check_empty: true)
+      return false if check_empty && empty_required_value?(value)
+      return true if value.nil? && !required?
+
+      (value && enums.include?(value.to_s))
+    end
+
+    def normalize(value = self.value)
+      !valid?(value) ? nil : value.to_s
+    end
+
+    def desc=(value)
+      self.desc_string = value
+      desc
+    end
+
+    def desc
+      str = enums.join(', ') if enums
+      "#{desc_string || ''} (Accepted: #{str})"
+    end
+
+    protected
+
+    attr_accessor :desc_string # :nodoc:
   end
-
-
-protected
-
-  attr_accessor :desc_string # :nodoc:
-
-end
-
 end

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -21,7 +21,7 @@ module Msf
       return false if check_empty && empty_required_value?(value)
       return true if value.nil? && !required?
 
-      (value && enums.include?(value.to_s))
+      !value.nil? && enums.include?(value.to_s)
     end
 
     def normalize(value = self.value)

--- a/lib/msf/core/payload/android/reverse_http.rb
+++ b/lib/msf/core/payload/android/reverse_http.rb
@@ -23,11 +23,7 @@ module Payload::Android::ReverseHttp
   #
   def initialize(*args)
     super
-    register_advanced_options([
-        OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
-        OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
-        OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header'])
-      ], self.class)
+    register_advanced_options(Msf::Opt::http_header_options)
   end
 
   #

--- a/lib/msf/core/payload/java/reverse_http.rb
+++ b/lib/msf/core/payload/java/reverse_http.rb
@@ -23,13 +23,13 @@ module Payload::Java::ReverseHttp
   #
   def initialize(*args)
     super
-    register_advanced_options([
-      OptInt.new('Spawn', [true, 'Number of subprocesses to spawn', 2]),
-      OptInt.new('StagerURILength', [false, 'The URI length for the stager (at least 5 bytes)']),
-      OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
-      OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
-      OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header']),
-    ])
+    register_advanced_options(
+      [
+        OptInt.new('Spawn', [true, 'Number of subprocesses to spawn', 2]),
+        OptInt.new('StagerURILength', [false, 'The URI length for the stager (at least 5 bytes)']),
+      ] +
+      Msf::Opt::http_header_options
+    )
   end
 
   #

--- a/lib/msf/core/payload/java/reverse_http.rb
+++ b/lib/msf/core/payload/java/reverse_http.rb
@@ -68,9 +68,9 @@ module Payload::Java::ReverseHttp
     c =  ''
     c << "Spawn=#{ds["Spawn"] || 2}\n"
     c << "HeaderUser-Agent=#{ds["HttpUserAgent"]}\n" if ds["HttpUserAgent"]
-    c << "HeaderHost=#{ds["HttpHeaderHost"]}\n" if ds["HttpHeaderHost"]
-    c << "HeaderReferer=#{ds["HttpHeaderReferer"]}\n" if ds["HttpHeaderReferer"]
-    c << "HeaderCookie=#{ds["HttpHeaderCookie"]}\n" if ds["HttpHeaderCookie"]
+    c << "HeaderHost=#{ds["HttpHostHeader"]}\n" if ds["HttpHostHeader"]
+    c << "HeaderReferer=#{ds["HttpReferer"]}\n" if ds["HttpReferer"]
+    c << "HeaderCookie=#{ds["HttpCookie"]}\n" if ds["HttpCookie"]
     c << "URL=#{scheme}://#{ds['LHOST']}"
     c << ":#{ds['LPORT']}" if ds['LPORT']
     c << luri

--- a/lib/msf/core/payload/java/reverse_http.rb
+++ b/lib/msf/core/payload/java/reverse_http.rb
@@ -67,7 +67,7 @@ module Payload::Java::ReverseHttp
 
     c =  ''
     c << "Spawn=#{ds["Spawn"] || 2}\n"
-    c << "HeaderUser-Agent=#{ds["MeterpreterUserAgent"]}\n" if ds["MeterpreterUserAgent"]
+    c << "HeaderUser-Agent=#{ds["HttpUserAgent"]}\n" if ds["HttpUserAgent"]
     c << "HeaderHost=#{ds["HttpHeaderHost"]}\n" if ds["HttpHeaderHost"]
     c << "HeaderReferer=#{ds["HttpHeaderReferer"]}\n" if ds["HttpHeaderReferer"]
     c << "HeaderCookie=#{ds["HttpHeaderCookie"]}\n" if ds["HttpHeaderCookie"]

--- a/lib/msf/core/payload/multi/reverse_http.rb
+++ b/lib/msf/core/payload/multi/reverse_http.rb
@@ -23,14 +23,13 @@ module Payload::Multi::ReverseHttp
   def initialize(*args)
     super
     register_advanced_options([
-        OptInt.new('StagerURILength', [false, 'The URI length for the stager (at least 5 bytes)']),
-        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
-          aliases: ['ReverseConnectRetries']),
-        OptString.new('PayloadProxyHost', [false, 'An optional proxy server IP address or hostname']),
-        OptPort.new('PayloadProxyPort', [false, 'An optional proxy server port']),
-        OptString.new('PayloadProxyUser', [false, 'An optional proxy server username']),
-        OptString.new('PayloadProxyPass', [false, 'An optional proxy server password']),
-        OptEnum.new('PayloadProxyType', [false, 'The type of HTTP proxy (HTTP or SOCKS)', 'HTTP', ['HTTP', 'SOCKS']])
+        OptInt.new('StagerURILength', 'The URI length for the stager (at least 5 bytes)'),
+        OptInt.new('StagerRetryCount', 'The number of times the stager should retry if the first connect fails', default: 10, aliases: ['ReverseConnectRetries']),
+        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname', aliases: ['PayloadProxyHost']),
+        OptPort.new('HttpProxyPort', 'An optional proxy server port', aliases: ['PayloadProxyPort']),
+        OptString.new('HttpProxyUser', 'An optional proxy server username', aliases: ['PayloadProxyUser']),
+        OptString.new('HttpProxyPass', 'An optional proxy server password', aliases: ['PayloadProxyPass']),
+        OptEnum.new('HttpProxyType', 'The type of HTTP proxy (HTTP or SOCKS)', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType'])
       ])
   end
 
@@ -67,4 +66,3 @@ module Payload::Multi::ReverseHttp
 end
 
 end
-

--- a/lib/msf/core/payload/multi/reverse_http.rb
+++ b/lib/msf/core/payload/multi/reverse_http.rb
@@ -22,15 +22,12 @@ module Payload::Multi::ReverseHttp
   #
   def initialize(*args)
     super
-    register_advanced_options([
-        OptInt.new('StagerURILength', 'The URI length for the stager (at least 5 bytes)'),
-        OptInt.new('StagerRetryCount', 'The number of times the stager should retry if the first connect fails', default: 10, aliases: ['ReverseConnectRetries']),
-        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname', aliases: ['PayloadProxyHost']),
-        OptPort.new('HttpProxyPort', 'An optional proxy server port', aliases: ['PayloadProxyPort']),
-        OptString.new('HttpProxyUser', 'An optional proxy server username', aliases: ['PayloadProxyUser']),
-        OptString.new('HttpProxyPass', 'An optional proxy server password', aliases: ['PayloadProxyPass']),
-        OptEnum.new('HttpProxyType', 'The type of HTTP proxy (HTTP or SOCKS)', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType'])
-      ])
+    register_advanced_options(
+      [ OptInt.new('StagerURILength', 'The URI length for the stager (at least 5 bytes)') ] +
+      Msf::Opt::stager_retry_options +
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   #

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -98,9 +98,9 @@ module Payload::Python::MeterpreterLoader
     http_user_agent = opts[:http_user_agent] || ds['HttpUserAgent']
     http_proxy_host = opts[:http_proxy_host] || ds['HttpProxyHost'] || ds['PROXYHOST']
     http_proxy_port = opts[:http_proxy_port] || ds['HttpProxyPort'] || ds['PROXYPORT']
-    http_header_host = opts[:header_host] || ds['HttpHeaderHost']
-    http_header_cookie = opts[:header_cookie] || ds['HttpHeaderCookie']
-    http_header_referer = opts[:header_referer] || ds['HttpHeaderReferer']
+    http_header_host = opts[:header_host] || ds['HttpHostHeader']
+    http_header_cookie = opts[:header_cookie] || ds['HttpCookie']
+    http_header_referer = opts[:header_referer] || ds['HttpReferer']
 
     # The callback URL can be different to the one that we're receiving from the interface
     # so we need to generate it

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -105,28 +105,30 @@ module Payload::Python::MeterpreterLoader
     # The callback URL can be different to the one that we're receiving from the interface
     # so we need to generate it
     # TODO: move this to somewhere more common so that it can be used across payload types
-    uri = "/#{(opts[:uri].to_s == '' ? opts[:url] : opts[:uri].to_s).split('/').reject(&:empty?)[-1]}"
-    callback_url = [
-      opts[:url].split(':')[0],
-      '://',
-      (ds['OverrideRequestHost'] == true ? ds['OverrideRequestLHOST'] : ds['LHOST']).to_s,
-      ':',
-      (ds['OverrideRequestHost'] == true ? ds['OverrideRequestLPORT'] : ds['LPORT']).to_s,
-      ds['LURI'].to_s,
-      uri,
-      '/'
-    ].join('')
+    unless opts[:url].to_s == ''
+      uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
+      callback_url = [
+        opts[:url].to_s.split(':')[0],
+        '://',
+        (ds['OverrideRequestHost'] == true ? ds['OverrideRequestLHOST'] : ds['LHOST']).to_s,
+        ':',
+        (ds['OverrideRequestHost'] == true ? ds['OverrideRequestLPORT'] : ds['LPORT']).to_s,
+        ds['LURI'].to_s,
+        uri,
+        '/'
+      ].join('')
 
-    # patch in the various payload related configuration
-    met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")
-    met.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(http_user_agent)}'") if http_user_agent.to_s != ''
-    met.sub!('HTTP_COOKIE = None', "HTTP_COOKIE = '#{var_escape.call(http_header_cookie)}'") if http_header_cookie.to_s != ''
-    met.sub!('HTTP_HOST = None', "HTTP_HOST = '#{var_escape.call(http_header_host)}'") if http_header_host.to_s != ''
-    met.sub!('HTTP_REFERER = None', "HTTP_REFERER = '#{var_escape.call(http_header_referer)}'") if http_header_referer.to_s != ''
+      # patch in the various payload related configuration
+      met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")
+      met.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(http_user_agent)}'") if http_user_agent.to_s != ''
+      met.sub!('HTTP_COOKIE = None', "HTTP_COOKIE = '#{var_escape.call(http_header_cookie)}'") if http_header_cookie.to_s != ''
+      met.sub!('HTTP_HOST = None', "HTTP_HOST = '#{var_escape.call(http_header_host)}'") if http_header_host.to_s != ''
+      met.sub!('HTTP_REFERER = None', "HTTP_REFERER = '#{var_escape.call(http_header_referer)}'") if http_header_referer.to_s != ''
 
-    if http_proxy_host.to_s != ''
-      proxy_url = "http://#{http_proxy_host}:#{http_proxy_port}"
-      met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(proxy_url)}'")
+      if http_proxy_host.to_s != ''
+        proxy_url = "http://#{http_proxy_host}:#{http_proxy_port}"
+        met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(proxy_url)}'")
+      end
     end
 
     # patch in any optional stageless tcp socket setup

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -28,13 +28,20 @@ module Payload::Python::MeterpreterLoader
       'Stager'        => {'Payload' => ""}
     ))
 
-    register_advanced_options([
-      OptBool.new('MeterpreterTryToFork', [ true, 'Fork a new process if the functionality is available', true ]),
-      OptBool.new('PythonMeterpreterDebug', [ true, 'Enable debugging for the Python meterpreter', false ]),
-      OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
-      OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
-      OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header'])
-    ], self.class)
+    register_advanced_options(
+      [
+        OptBool.new(
+          'MeterpreterTryToFork',
+          'Fork a new process if the functionality is available',
+          default: true
+        ),
+        OptBool.new(
+          'PythonMeterpreterDebug',
+          'Enable debugging for the Python meterpreter'
+        ),
+      ] +
+      Msf::Opt::http_header_options
+    )
   end
 
   def stage_payload(opts={})

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -88,9 +88,9 @@ module Payload::Python::MeterpreterLoader
     end
     met.sub!("SESSION_GUID = \'\'", "SESSION_GUID = \'#{session_guid}\'")
 
-    http_user_agent = opts[:http_user_agent] || ds['MeterpreterUserAgent']
-    http_proxy_host = opts[:http_proxy_host] || ds['PayloadProxyHost'] || ds['PROXYHOST']
-    http_proxy_port = opts[:http_proxy_port] || ds['PayloadProxyPort'] || ds['PROXYPORT']
+    http_user_agent = opts[:http_user_agent] || ds['HttpUserAgent']
+    http_proxy_host = opts[:http_proxy_host] || ds['HttpProxyHost'] || ds['PROXYHOST']
+    http_proxy_port = opts[:http_proxy_port] || ds['HttpProxyPort'] || ds['PROXYPORT']
     http_header_host = opts[:header_host] || ds['HttpHeaderHost']
     http_header_cookie = opts[:header_cookie] || ds['HttpHeaderCookie']
     http_header_referer = opts[:header_referer] || ds['HttpHeaderReferer']

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -13,8 +13,8 @@ module Payload::Python::ReverseHttp
     super(info)
     register_options(
       [
-        OptString.new('PayloadProxyHost', [ false, "The proxy server's IP address" ]),
-        OptPort.new('PayloadProxyPort', [ true, "The proxy port to connect to", 8080 ]),
+        OptString.new('HttpProxyHost', [ false, "The proxy server's IP address" ], aliases: ['PayloadProxyHost']),
+        OptPort.new('HttpProxyPort', [ true, "The proxy port to connect to", 8080 ], aliases: ['PayloadProxyHost']),
         OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
         OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
         OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header'])
@@ -29,9 +29,9 @@ module Payload::Python::ReverseHttp
     opts.merge!({
       host:           ds['LHOST'] || '127.127.127.127',
       port:           ds['LPORT'],
-      proxy_host:     ds['PayloadProxyHost'],
-      proxy_port:     ds['PayloadProxyPort'],
-      user_agent:     ds['MeterpreterUserAgent'],
+      proxy_host:     ds['HttpProxyHost'],
+      proxy_port:     ds['HttpProxyPort'],
+      user_agent:     ds['HttpUserAgent'],
       header_host:    ds['HttpHeaderHost'],
       header_cookie:  ds['HttpHeaderCookie'],
       header_referer: ds['HttpHeaderReferer']

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -28,9 +28,9 @@ module Payload::Python::ReverseHttp
       proxy_host:     ds['HttpProxyHost'],
       proxy_port:     ds['HttpProxyPort'],
       user_agent:     ds['HttpUserAgent'],
-      header_host:    ds['HttpHeaderHost'],
-      header_cookie:  ds['HttpHeaderCookie'],
-      header_referer: ds['HttpHeaderReferer']
+      header_host:    ds['HttpHostHeader'],
+      header_cookie:  ds['HttpCookie'],
+      header_referer: ds['HttpReferer']
     })
     opts[:scheme] = 'http' if opts[:scheme].nil?
 

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -11,14 +11,10 @@ module Payload::Python::ReverseHttp
 
   def initialize(info = {})
     super(info)
-    register_options(
-      [
-        OptString.new('HttpProxyHost', [ false, "The proxy server's IP address" ], aliases: ['PayloadProxyHost']),
-        OptPort.new('HttpProxyPort', [ true, "The proxy port to connect to", 8080 ], aliases: ['PayloadProxyHost']),
-        OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
-        OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
-        OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header'])
-      ], self.class)
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   #

--- a/lib/msf/core/payload/python/reverse_tcp.rb
+++ b/lib/msf/core/payload/python/reverse_tcp.rb
@@ -18,11 +18,7 @@ module Payload::Python::ReverseTcp
 
   def initialize(*args)
     super
-    register_advanced_options([
-        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
-          aliases: ['ReverseConnectRetries']),
-        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts', 5])
-      ], self.class)
+    register_advanced_options(Msf::Opt::stager_retry_options)
   end
 
   #

--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -17,11 +17,7 @@ module Payload::Python::ReverseTcpSsl
   include Msf::Payload::Python::ReverseTcp
   def initialize(*args)
     super
-    register_advanced_options([
-        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
-          aliases: ['ReverseConnectRetries']),
-        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts', 5])
-      ], self.class)
+    register_advanced_options(Msf::Opt::stager_retry_options)
   end
 
   #

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -83,9 +83,9 @@ private
 
   def get_custom_headers(ds)
     headers = ""
-    headers << "Host: #{ds['HttpHeaderHost']}\r\n" if ds['HttpHeaderHost']
-    headers << "Cookie: #{ds['HttpHeaderCookie']}\r\n" if ds['HttpHeaderCookie']
-    headers << "Referer: #{ds['HttpHeaderReferer']}\r\n" if ds['HttpHeaderReferer']
+    headers << "Host: #{ds['HttpHostHeader']}\r\n" if ds['HttpHostHeader']
+    headers << "Cookie: #{ds['HttpCookie']}\r\n" if ds['HttpCookie']
+    headers << "Referer: #{ds['HttpReferer']}\r\n" if ds['HttpReferer']
 
     if headers.length > 0
       headers

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -60,12 +60,12 @@ module Msf::Payload::TransportConfig
       lhost:           opts[:lhost] || ds['LHOST'],
       lport:           (opts[:lport] || ds['LPORT']).to_i,
       uri:             uri,
-      ua:              ds['MeterpreterUserAgent'],
-      proxy_host:      ds['PayloadProxyHost'],
-      proxy_port:      ds['PayloadProxyPort'],
-      proxy_type:      ds['PayloadProxyType'],
-      proxy_user:      ds['PayloadProxyUser'],
-      proxy_pass:      ds['PayloadProxyPass'],
+      ua:              ds['HttpUserAgent'],
+      proxy_host:      ds['HttpProxyHost'],
+      proxy_port:      ds['HttpProxyPort'],
+      proxy_type:      ds['HttpProxyType'],
+      proxy_user:      ds['HttpProxyUser'],
+      proxy_pass:      ds['HttpProxyPass'],
       custom_headers:  get_custom_headers(ds)
     }.merge(timeout_config(opts))
   end

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -32,14 +32,14 @@ module Payload::Windows::ReverseHttp
         OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
           aliases: ['ReverseConnectRetries']),
         OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts', 5]),
-        OptString.new('PayloadProxyHost', [false, 'An optional proxy server IP address or hostname']),
-        OptPort.new('PayloadProxyPort', [false, 'An optional proxy server port']),
-        OptString.new('PayloadProxyUser', [false, 'An optional proxy server username']),
-        OptString.new('PayloadProxyPass', [false, 'An optional proxy server password']),
-        OptEnum.new('PayloadProxyType', [false, 'The type of HTTP proxy (HTTP or SOCKS)', 'HTTP', ['HTTP', 'SOCKS']]),
-        OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
-        OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
-        OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header'])
+        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname', aliases: ['PayloadProxyHost']),
+        OptPort.new('HttpProxyPort', 'An optional proxy server port', aliases: ['PayloadProxyPort']),
+        OptString.new('HttpProxyUser', 'An optional proxy server username', aliases: ['PayloadProxyUser']),
+        OptString.new('HttpProxyPass', 'An optional proxy server password', aliases: ['PayloadProxyPass']),
+        OptEnum.new('HttpProxyType', 'The type of HTTP proxy (HTTP or SOCKS)', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType']),
+        OptString.new('HttpHeaderHost', 'An optional value to use for the Host HTTP header'),
+        OptString.new('HttpHeaderCookie', 'An optional value to use for the Cookie HTTP header'),
+        OptString.new('HttpHeaderReferer', 'An optional value to use for the Referer HTTP header')
       ], self.class)
   end
 
@@ -60,12 +60,12 @@ module Payload::Windows::ReverseHttp
     if self.available_space.nil? || required_space <= self.available_space
       conf[:url]            = luri + generate_uri(opts)
       conf[:exitfunk]       = ds['EXITFUNC']
-      conf[:ua]             = ds['MeterpreterUserAgent']
-      conf[:proxy_host]     = ds['PayloadProxyHost']
-      conf[:proxy_port]     = ds['PayloadProxyPort']
-      conf[:proxy_user]     = ds['PayloadProxyUser']
-      conf[:proxy_pass]     = ds['PayloadProxyPass']
-      conf[:proxy_type]     = ds['PayloadProxyType']
+      conf[:ua]             = ds['HttpUserAgent']
+      conf[:proxy_host]     = ds['HttpProxyHost']
+      conf[:proxy_port]     = ds['HttpProxyPort']
+      conf[:proxy_user]     = ds['HttpProxyUser']
+      conf[:proxy_pass]     = ds['HttpProxyPass']
+      conf[:proxy_type]     = ds['HttpProxyType']
       conf[:custom_headers] = get_custom_headers(ds)
     else
       # Otherwise default to small URIs

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -72,9 +72,9 @@ module Payload::Windows::ReverseHttp
   #
   def get_custom_headers(ds)
     headers = ""
-    headers << "Host: #{ds['HttpHeaderHost']}\r\n" if ds['HttpHeaderHost']
-    headers << "Cookie: #{ds['HttpHeaderCookie']}\r\n" if ds['HttpHeaderCookie']
-    headers << "Referer: #{ds['HttpHeaderReferer']}\r\n" if ds['HttpHeaderReferer']
+    headers << "Host: #{ds['HttpHostHeader']}\r\n" if ds['HttpHostHeader']
+    headers << "Cookie: #{ds['HttpCookie']}\r\n" if ds['HttpCookie']
+    headers << "Referer: #{ds['HttpReferer']}\r\n" if ds['HttpReferer']
 
     if headers.length > 0
       headers

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -27,20 +27,12 @@ module Payload::Windows::ReverseHttp
   #
   def initialize(*args)
     super
-    register_advanced_options([
-        OptInt.new('StagerURILength', [false, 'The URI length for the stager (at least 5 bytes)']),
-        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
-          aliases: ['ReverseConnectRetries']),
-        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts', 5]),
-        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname', aliases: ['PayloadProxyHost']),
-        OptPort.new('HttpProxyPort', 'An optional proxy server port', aliases: ['PayloadProxyPort']),
-        OptString.new('HttpProxyUser', 'An optional proxy server username', aliases: ['PayloadProxyUser']),
-        OptString.new('HttpProxyPass', 'An optional proxy server password', aliases: ['PayloadProxyPass']),
-        OptEnum.new('HttpProxyType', 'The type of HTTP proxy (HTTP or SOCKS)', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType']),
-        OptString.new('HttpHeaderHost', 'An optional value to use for the Host HTTP header'),
-        OptString.new('HttpHeaderCookie', 'An optional value to use for the Cookie HTTP header'),
-        OptString.new('HttpHeaderReferer', 'An optional value to use for the Referer HTTP header')
-      ], self.class)
+    register_advanced_options(
+      [ OptInt.new('StagerURILength', 'The URI length for the stager (at least 5 bytes)') ] +
+      Msf::Opt::stager_retry_options +
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   #

--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -21,7 +21,7 @@ module Payload::Windows::ReverseWinHttp
   def initialize(*args)
     super
     register_advanced_options([
-        OptBool.new('PayloadProxyIE', [false, 'Enable use of IE proxy settings', true])
+        OptBool.new('HttpProxyIE', 'Enable use of IE proxy settings', default: true, aliases: ['PayloadProxyIE'])
       ], self.class)
   end
 
@@ -41,13 +41,13 @@ module Payload::Windows::ReverseWinHttp
       conf[:uri]              = luri + generate_uri
       conf[:exitfunk]         = ds['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]
-      conf[:proxy_host]       = ds['PayloadProxyHost']
-      conf[:proxy_port]       = ds['PayloadProxyPort']
-      conf[:proxy_user]       = ds['PayloadProxyUser']
-      conf[:proxy_pass]       = ds['PayloadProxyPass']
-      conf[:proxy_type]       = ds['PayloadProxyType']
+      conf[:proxy_host]       = ds['HttpProxyHost']
+      conf[:proxy_port]       = ds['HttpProxyPort']
+      conf[:proxy_user]       = ds['HttpProxyUser']
+      conf[:proxy_pass]       = ds['HttpProxyPass']
+      conf[:proxy_type]       = ds['HttpProxyType']
       conf[:retry_count]      = ds['StagerRetryCount']
-      conf[:proxy_ie]         = ds['PayloadProxyIE']
+      conf[:proxy_ie]         = ds['HttpProxyIE']
       conf[:custom_headers]   = get_custom_headers(ds)
     else
       # Otherwise default to small URIs

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -77,9 +77,9 @@ module Payload::Windows::ReverseHttp_x64
   #
   def get_custom_headers(ds)
     headers = ""
-    headers << "Host: #{ds['HttpHeaderHost']}\r\n" if ds['HttpHeaderHost']
-    headers << "Cookie: #{ds['HttpHeaderCookie']}\r\n" if ds['HttpHeaderCookie']
-    headers << "Referer: #{ds['HttpHeaderReferer']}\r\n" if ds['HttpHeaderReferer']
+    headers << "Host: #{ds['HttpHostHeader']}\r\n" if ds['HttpHostHeader']
+    headers << "Cookie: #{ds['HttpCookie']}\r\n" if ds['HttpCookie']
+    headers << "Referer: #{ds['HttpReferer']}\r\n" if ds['HttpReferer']
 
     if headers.length > 0
       headers

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -32,14 +32,14 @@ module Payload::Windows::ReverseHttp_x64
         OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
           aliases: ['ReverseConnectRetries']),
         OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts', 5]),
-        OptString.new('PayloadProxyHost', [false, 'An optional proxy server IP address or hostname']),
-        OptPort.new('PayloadProxyPort', [false, 'An optional proxy server port']),
-        OptString.new('PayloadProxyUser', [false, 'An optional proxy server username']),
-        OptString.new('PayloadProxyPass', [false, 'An optional proxy server password']),
-        OptEnum.new('PayloadProxyType', [false, 'The type of HTTP proxy (HTTP or SOCKS)', 'HTTP', ['HTTP', 'SOCKS']]),
-        OptString.new('HttpHeaderHost', [false, 'An optional value to use for the Host HTTP header']),
-        OptString.new('HttpHeaderCookie', [false, 'An optional value to use for the Cookie HTTP header']),
-        OptString.new('HttpHeaderReferer', [false, 'An optional value to use for the Referer HTTP header'])
+        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname', aliases: ['PayloadProxyHost']),
+        OptPort.new('HttpProxyPort', 'An optional proxy server port', aliases: ['PayloadProxyPort']),
+        OptString.new('HttpProxyUser', 'An optional proxy server username', aliases: ['PayloadProxyUser']),
+        OptString.new('HttpProxyPass', 'An optional proxy server password', aliases: ['PayloadProxyPass']),
+        OptEnum.new('HttpProxyType', 'The type of HTTP proxy (HTTP or SOCKS)', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType']),
+        OptString.new('HttpHeaderHost', 'An optional value to use for the Host HTTP header'),
+        OptString.new('HttpHeaderCookie', 'An optional value to use for the Cookie HTTP header'),
+        OptString.new('HttpHeaderReferer', 'An optional value to use for the Referer HTTP header')
       ], self.class)
   end
 
@@ -65,12 +65,12 @@ module Payload::Windows::ReverseHttp_x64
     if self.available_space.nil? || required_space <= self.available_space
       conf[:url]        = luri + generate_uri(opts)
       conf[:exitfunk]   = ds['EXITFUNC']
-      conf[:ua]         = ds['MeterpreterUserAgent']
-      conf[:proxy_host] = ds['PayloadProxyHost']
-      conf[:proxy_port] = ds['PayloadProxyPort']
-      conf[:proxy_user] = ds['PayloadProxyUser']
-      conf[:proxy_pass] = ds['PayloadProxyPass']
-      conf[:proxy_type] = ds['PayloadProxyType']
+      conf[:ua]         = ds['HttpUserAgent']
+      conf[:proxy_host] = ds['HttpProxyHost']
+      conf[:proxy_port] = ds['HttpProxyPort']
+      conf[:proxy_user] = ds['HttpProxyUser']
+      conf[:proxy_pass] = ds['HttpProxyPass']
+      conf[:proxy_type] = ds['HttpProxyType']
       conf[:custom_headers] = get_custom_headers(ds)
      else
       # Otherwise default to small URIs

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -27,20 +27,12 @@ module Payload::Windows::ReverseHttp_x64
   #
   def initialize(*args)
     super
-    register_advanced_options([
-        OptInt.new('StagerURILength', [false, 'The URI length for the stager (at least 5 bytes)']),
-        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails', 10],
-          aliases: ['ReverseConnectRetries']),
-        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts', 5]),
-        OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname', aliases: ['PayloadProxyHost']),
-        OptPort.new('HttpProxyPort', 'An optional proxy server port', aliases: ['PayloadProxyPort']),
-        OptString.new('HttpProxyUser', 'An optional proxy server username', aliases: ['PayloadProxyUser']),
-        OptString.new('HttpProxyPass', 'An optional proxy server password', aliases: ['PayloadProxyPass']),
-        OptEnum.new('HttpProxyType', 'The type of HTTP proxy (HTTP or SOCKS)', enums: ['HTTP', 'SOCKS'], aliases: ['PayloadProxyType']),
-        OptString.new('HttpHeaderHost', 'An optional value to use for the Host HTTP header'),
-        OptString.new('HttpHeaderCookie', 'An optional value to use for the Cookie HTTP header'),
-        OptString.new('HttpHeaderReferer', 'An optional value to use for the Referer HTTP header')
-      ], self.class)
+    register_advanced_options(
+      [ OptInt.new('StagerURILength', 'The URI length for the stager (at least 5 bytes)') ] +
+      Msf::Opt::stager_retry_options +
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
   end
 
   def transport_config(opts={})

--- a/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
@@ -22,7 +22,7 @@ module Payload::Windows::ReverseWinHttp_x64
   def initialize(*args)
     super
     register_advanced_options([
-        OptBool.new('PayloadProxyIE', [false, 'Enable use of IE proxy settings', true])
+        OptBool.new('HttpProxyIE', 'Enable use of IE proxy settings', default: true, aliases: ['PayloadProxyIE'])
       ], self.class)
   end
 
@@ -42,13 +42,13 @@ module Payload::Windows::ReverseWinHttp_x64
       conf[:uri]              = luri + generate_uri
       conf[:exitfunk]         = ds['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]
-      conf[:proxy_host]       = ds['PayloadProxyHost']
-      conf[:proxy_port]       = ds['PayloadProxyPort']
-      conf[:proxy_user]       = ds['PayloadProxyUser']
-      conf[:proxy_pass]       = ds['PayloadProxyPass']
-      conf[:proxy_type]       = ds['PayloadProxyType']
+      conf[:proxy_host]       = ds['HttpProxyHost']
+      conf[:proxy_port]       = ds['HttpProxyPort']
+      conf[:proxy_user]       = ds['HttpProxyUser']
+      conf[:proxy_pass]       = ds['HttpProxyPass']
+      conf[:proxy_type]       = ds['HttpProxyType']
       conf[:retry_count]      = ds['StagerRetryCount']
-      conf[:proxy_ie]         = ds['PayloadProxyIE']
+      conf[:proxy_ie]         = ds['HttpProxyIE']
       conf[:custom_headers]   = get_custom_headers(ds)
     else
       # Otherwise default to small URIs

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -142,7 +142,7 @@ class Console::CommandDispatcher::Core
     print_line(@@pivot_opts.usage)
     print_line
     print_line('Supported pivot types:')
-    print_line('     - pipe (using named pipes over SMB)') 
+    print_line('     - pipe (using named pipes over SMB)')
     print_line('Supported arhiectures:')
     @@pivot_supported_archs.each do |a|
       print_line('     - ' + a)

--- a/modules/auxiliary/gather/emc_cta_xxe.rb
+++ b/modules/auxiliary/gather/emc_cta_xxe.rb
@@ -30,10 +30,10 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(443),
         OptBool.new('SSL', [true, 'Use SSL', true]),
-        OptString.new('SSLVersion', [true, 'SSL version', 'TLS1']),
         OptString.new('TARGETURI', [ true, "Base directory path", '/']),
         OptString.new('FILEPATH', [true, "The filepath to read on the server", "/etc/shadow"]),
-      ])
+      ]
+    )
   end
 
   def run

--- a/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
@@ -13,23 +13,18 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
 
   def initialize
-  super(
-    'Name'        => 'Nessus NTP Login Utility',
-    'Description' => 'This module attempts to authenticate to a Nessus NTP service.',
-    'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-    'License'        => MSF_LICENSE
-  )
-  register_options(
-    [
-      Opt::RPORT(1241),
-      OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
-    ])
-
-  register_advanced_options(
-  [
-    OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-    OptString.new('SSLVersion', [ true, " Specify the version of SSL that should be used", "TLS1"])
-  ])
+    super(
+      'Name'        => 'Nessus NTP Login Utility',
+      'Description' => 'This module attempts to authenticate to a Nessus NTP service.',
+      'Author'      => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'     => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(1241),
+        OptBool.new('BLANK_PASSWORDS', "Try blank passwords for all users")
+      ]
+    )
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -10,23 +10,18 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
 
   def initialize
-  super(
-    'Name'        => 'OpenVAS OMP Login Utility',
-    'Description' => 'This module attempts to authenticate to an OpenVAS OMP service.',
-    'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-    'License'        => MSF_LICENSE
-  )
-  register_options(
-    [
-      Opt::RPORT(9390),
-      OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
-    ])
-
-  register_advanced_options(
-  [
-    OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-    OptString.new('SSLVersion', [ true, " Specify the version of SSL that should be used", "TLS1"])
-  ])
+    super(
+      'Name'        => 'OpenVAS OMP Login Utility',
+      'Description' => 'This module attempts to authenticate to an OpenVAS OMP service.',
+      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'        => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(9390),
+        OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
+      ]
+    )
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -10,23 +10,18 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
 
   def initialize
-  super(
-    'Name'        => 'OpenVAS OTP Login Utility',
-    'Description' => 'This module attempts to authenticate to an OpenVAS OTP service.',
-    'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-    'License'        => MSF_LICENSE
-  )
-  register_options(
-    [
-      Opt::RPORT(9391),
-      OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
-    ])
-
-  register_advanced_options(
-  [
-    OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-    OptString.new('SSLVersion', [ true, " Specify the version of SSL that should be used", "TLS1"])
-  ])
+    super(
+      'Name'        => 'OpenVAS OTP Login Utility',
+      'Description' => 'This module attempts to authenticate to an OpenVAS OTP service.',
+      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'        => MSF_LICENSE
+    )
+    register_options(
+      [
+        Opt::RPORT(9391),
+        OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
+      ]
+    )
   end
 
   def run_host(ip)

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -80,8 +80,8 @@ module MetasploitModule
     p[i, u.length] = u
 
     # patch proxy info
-    proxyhost = datastore['PayloadProxyHost'].to_s
-    proxyport = datastore['PayloadProxyPort'].to_s || "8080"
+    proxyhost = datastore['HttpProxyHost'].to_s
+    proxyport = datastore['HttpProxyPort'].to_s || "8080"
 
     if Rex::Socket.is_ipv6?(proxyhost)
       proxyhost = "[#{proxyhost}]"
@@ -91,7 +91,7 @@ module MetasploitModule
     if proxyport == "80"
       proxyinfo = proxyhost
     end
-    if datastore['PayloadProxyType'].to_s == 'HTTP'
+    if datastore['HttpProxyType'].to_s == 'HTTP'
       proxyinfo = 'http://' + proxyinfo
     else #socks
       proxyinfo = 'socks=' + proxyinfo
@@ -105,22 +105,22 @@ module MetasploitModule
     p[proxyloc-4] = [calloffset].pack('V')[0]
 
     # Authentication credentials have not been specified
-    if datastore['PayloadProxyUser'].to_s == '' or
-       datastore['PayloadProxyPass'].to_s == '' or
-       datastore['PayloadProxyType'].to_s     == 'SOCKS'
+    if datastore['HttpProxyUser'].to_s == '' ||
+       datastore['HttpProxyPass'].to_s == '' ||
+       datastore['HttpProxyType'].to_s == 'SOCKS'
 
       jmp_offset = p.index("PROXY_AUTH_STOP") + 15 - p.index("PROXY_AUTH_START")
 
       # Remove the authentication code
       p = p.gsub(/PROXY_AUTH_START(.)*PROXY_AUTH_STOP/i, "")
     else
-      username_size_diff = 14 - datastore['PayloadProxyUser'].to_s.length
-      password_size_diff = 14 - datastore['PayloadProxyPass'].to_s.length
+      username_size_diff = 14 - datastore['HttpProxyUser'].to_s.length
+      password_size_diff = 14 - datastore['HttpProxyPass'].to_s.length
       jmp_offset =
         16 + # PROXY_AUTH_START length
         15 + # PROXY_AUTH_STOP length
-        username_size_diff + # Difference between datastore PayloadProxyUser length  and db "PayloadProxyUser length"
-        password_size_diff   # Same with PayloadProxyPass
+        username_size_diff + # Difference between datastore HttpProxyUser length  and db "HttpProxyUser length"
+        password_size_diff   # Same with HttpProxyPass
 
       # Patch call offset
       username_loc = p.index("PROXY_USERNAME")
@@ -131,8 +131,8 @@ module MetasploitModule
       # Remove markers & change login/password
       p = p.gsub("PROXY_AUTH_START","")
       p = p.gsub("PROXY_AUTH_STOP","")
-      p = p.gsub("PROXY_USERNAME", datastore['PayloadProxyUser'].to_s)
-      p = p.gsub("PROXY_PASSWORD", datastore['PayloadProxyPass'].to_s)
+      p = p.gsub("PROXY_USERNAME", datastore['HttpProxyUser'].to_s)
+      p = p.gsub("PROXY_PASSWORD", datastore['HttpProxyPass'].to_s)
     end
 
     # Patch jmp dbl_get_server_host


### PR DESCRIPTION
This is one of those 'fix broken windows when you find them' commits, sorry for the extra length.

The first thing I did here was get annoyed by the module option declaration API, so I extended that along the way to not require as much boilerplate, while staying backward compatible. You'll notice that the newly DRY'd options use the newer more explicit syntax for specifying default values, enums, etc.

This also renames a number of parameters, the Proxy options and Http options, to all start with Http, including aliases for backward compatibility as well.

This resulted in a net addition for lines of code, mostly because I expanded a few option declarations to take multiple lines for better readability.