### PR TITLE
Add the missing command id for stdapi_fs_delete

### DIFF
--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -293,6 +293,7 @@ METHOD_LIST = {
   'stdapi_webcam_list' =>  2114,
   'stdapi_webcam_start' =>  2115,
   'stdapi_webcam_stop' =>  2116,
+  'stdapi_fs_delete' => 2117,
 
   'priv_elevate_getsystem' =>  3000,
   'priv_fs_blank_directory_mace' =>  3001,


### PR DESCRIPTION
Add the `stdapi_fs_delete` command ID. It's currently implemented by the [php meterpreter](https://github.com/rapid7/metasploit-payloads/blob/baf0aac9efde1cb5fa5b2344078581100558ae2f/php/meterpreter/ext_server_stdapi.php#L392) and the [python meterpreter](https://github.com/rapid7/metasploit-payloads/blob/45165bc6ee7fb27e49308e95ed4100b9e034a679/python/meterpreter/ext_server_stdapi.py#L1264).