### PR TITLE
Fix stageless Windows Meterpreter config slot

### DIFF
--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -59,6 +59,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -59,6 +59,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end


### PR DESCRIPTION
Adds the necessary 8 byte buffer to the beginning of the config block. We should look at centralizing it later, but for now this should get us unblocked.